### PR TITLE
Add the Amethyst game engine book

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 | Name | Description | Contribute |
 |:----|:-----------|:-------:|
+| [Amethyst](https://www.amethyst.rs/book/latest/) | The Amethyst game engine book | [Github](https://github.com/amethyst/amethyst) |
 | [cargo](https://doc.rust-lang.org/cargo/) | The cargo book | 🤷 |
 | [Command Line Applications in Rust](https://rust-lang-nursery.github.io/cli-wg/) | A book about writing CLI's in Rust | [Github](https://github.com/rust-lang-nursery/cli-wg/tree/master/src) |
 | [Hello wasm-pack!](https://rustwasm.github.io/wasm-pack/book/) | The wasm-pack guide | [Github](https://github.com/rustwasm/wasm-pack/tree/master/docs/src) |


### PR DESCRIPTION
This adds the Amethyst game engines book as an example of mdBook. It uses a lot of its features including testing the code within the book to make sure that it's valid code.