### PR TITLE
Fix links to books about embedded Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 | [Amethyst](https://www.amethyst.rs/book/latest/) | The Amethyst game engine book | [Github](https://github.com/amethyst/amethyst) |
 | [cargo](https://doc.rust-lang.org/cargo/) | The cargo book | [Github](https://github.com/rust-lang/cargo/tree/master/src/doc/src) |
 | [Command Line Applications in Rust](https://rust-lang-nursery.github.io/cli-wg/) | A book about writing CLI's in Rust | [Github](https://github.com/rust-lang-nursery/cli-wg/tree/master/src) |
-| [Discovery](https://rust-embedded.github.io/bookshelf/discovery/index.html) | The Discovery Book will teach you about microcontrollers, peripherals, sensors and bare metal programming in Rust | [GitHub](https://github.com/rust-embedded/discovery) |
-| [The Embedded Rust Book](https://rust-embedded.github.io/bookshelf/book/index.html) | The Embedded Rust Book will get you up to speed with embedded Rust development | [GitHub](https://github.com/rust-embedded/book) |
-| [The Embedonomicon](https://rust-embedded.github.io/bookshelf/embedonomicon/index.html) | For those that want to dive into the implementation of the foundational crates of the embedded ecosystem | [GitHub](https://github.com/rust-embedded/embedonomicon) |
+| [Discovery](https://docs.rust-embedded.org/discovery/index.html) | The Discovery Book will teach you about microcontrollers, peripherals, sensors and bare metal programming in Rust | [GitHub](https://github.com/rust-embedded/discovery) |
+| [The Embedded Rust Book](https://docs.rust-embedded.org/book/index.html) | The Embedded Rust Book will get you up to speed with embedded Rust development | [GitHub](https://github.com/rust-embedded/book) |
+| [The Embedonomicon](https://docs.rust-embedded.org/embedonomicon/index.html) | For those that want to dive into the implementation of the foundational crates of the embedded ecosystem | [GitHub](https://github.com/rust-embedded/embedonomicon) |
 | [Hello wasm-pack!](https://rustwasm.github.io/wasm-pack/book/) | The wasm-pack guide | [Github](https://github.com/rustwasm/wasm-pack/tree/master/docs/src) |
 | [mdbook](https://rust-lang-nursery.github.io/mdBook/)| The mdBook user guide | [Github](https://github.com/rust-lang-nursery/mdBook)|
 | [Rustdoc Book](https://doc.rust-lang.org/stable/rustdoc/) | Guide for Rustdoc | 🤷 |


### PR DESCRIPTION
They have been moved recently in https://github.com/rust-embedded/discovery/pull/145, https://github.com/rust-embedded/book/pull/75 and https://github.com/rust-embedded/embedonomicon/pull/30.